### PR TITLE
Guard snapshot directory creation and add integration check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,33 @@ if(RAREXSEC_BUILD_APPS)
 endif()
 
 if(BUILD_TESTING)
-    # No top-level tests are defined yet.
+    find_program(RAREXSEC_BASH_EXECUTABLE NAMES bash)
+    if(NOT RAREXSEC_BASH_EXECUTABLE)
+        message(FATAL_ERROR "bash executable is required to run the integration tests")
+    endif()
+
+    find_program(RAREXSEC_ROOT_EXECUTABLE NAMES root)
+    if(NOT RAREXSEC_ROOT_EXECUTABLE)
+        message(FATAL_ERROR "root executable is required to run the integration tests")
+    endif()
+
+    set(RAREXSEC_TEST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    set(RAREXSEC_TEST_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/tests")
+    file(MAKE_DIRECTORY "${RAREXSEC_TEST_BINARY_DIR}")
+
+    set(RAREXSEC_SNAPSHOT_ANALYSIS_EXEC "${CMAKE_BINARY_DIR}/app/snapshot-analysis")
+
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/run_snapshot_analysis_imt.sh.in
+        ${RAREXSEC_TEST_BINARY_DIR}/run_snapshot_analysis_imt.sh
+        @ONLY)
+
+    execute_process(
+        COMMAND chmod a+x ${RAREXSEC_TEST_BINARY_DIR}/run_snapshot_analysis_imt.sh)
+
+    add_test(
+        NAME snapshot-analysis-imt
+        COMMAND ${RAREXSEC_BASH_EXECUTABLE} ${RAREXSEC_TEST_BINARY_DIR}/run_snapshot_analysis_imt.sh)
 endif()
 
 if(RAREXSEC_BUILD_LIB OR RAREXSEC_BUILD_APPS)

--- a/src/SnapshotPipelineBuilder.cpp
+++ b/src/SnapshotPipelineBuilder.cpp
@@ -21,6 +21,29 @@
 
 namespace {
 
+constexpr char kEventsTreeName[] = "events";
+
+class ImplicitMTGuard {
+  public:
+    ImplicitMTGuard() : was_enabled_{ROOT::IsImplicitMTEnabled()} {
+        if (was_enabled_) {
+            ROOT::DisableImplicitMT();
+        }
+    }
+
+    ImplicitMTGuard(const ImplicitMTGuard &) = delete;
+    ImplicitMTGuard &operator=(const ImplicitMTGuard &) = delete;
+
+    ~ImplicitMTGuard() {
+        if (was_enabled_) {
+            ROOT::EnableImplicitMT();
+        }
+    }
+
+  private:
+    bool was_enabled_;
+};
+
 std::string sanitiseComponent(std::string value) {
     std::string sanitised;
     sanitised.reserve(value.size());
@@ -185,6 +208,7 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
 
         log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Initialising", directories.size(),
                   "directory paths in", output_file);
+        ImplicitMTGuard imt_guard;
         std::unique_ptr<TFile> file{TFile::Open(output_file.c_str(), "RECREATE")};
         if (!file || file->IsZombie()) {
             log::fatal("SnapshotPipelineBuilder::snapshot", "Failed to open snapshot output", output_file,
@@ -200,9 +224,7 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
             log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Ensuring directory path", directory_path);
             TDirectory *current = file.get();
             log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Starting at directory", current->GetPath());
-            const std::size_t last_index = components.size() - 1;
-            for (std::size_t idx = 0; idx < last_index; ++idx) {
-                const auto &component = components[idx];
+            for (const auto &component : components) {
                 if (component.empty()) {
                     continue;
                 }
@@ -277,17 +299,57 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
         log::info("SnapshotPipelineBuilder::snapshot", "Preparing to write", total_trees, "trees to", output_file);
     }
 
-    auto snapshot_tree = [&](ROOT::RDF::RNode df, const std::string &tree_path) {
+    const auto relocateTreeToDirectory = [&](const std::string &directory_path) {
+        if (directory_path.empty()) {
+            return;
+        }
+
+        ImplicitMTGuard imt_guard;
+        std::unique_ptr<TFile> file{TFile::Open(output_file.c_str(), "UPDATE")};
+        if (!file || file->IsZombie()) {
+            log::fatal("SnapshotPipelineBuilder::snapshot", "Failed to reopen snapshot output", output_file,
+                       "with mode", "UPDATE");
+        }
+
+        TDirectory *target_dir = file->GetDirectory(directory_path.c_str());
+        if (!target_dir) {
+            log::fatal("SnapshotPipelineBuilder::snapshot", "Requested target directory", directory_path,
+                       "is not available in", output_file);
+        }
+
+        TObject *object = file->Get(kEventsTreeName);
+        auto *tree = dynamic_cast<TTree *>(object);
+        if (!tree) {
+            log::fatal("SnapshotPipelineBuilder::snapshot", "Expected tree", kEventsTreeName,
+                       "not found in", output_file, "after snapshot");
+        }
+
+        target_dir->cd();
+        tree->SetDirectory(target_dir);
+        tree->Write("", TObject::kOverwrite);
+        file->cd();
+        file->Delete((std::string(kEventsTreeName) + ";*").c_str());
+        delete tree;
+        file->Write("", TObject::kOverwrite);
+        log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Relocated tree",
+                  directory_path + '/' + kEventsTreeName, "into", output_file);
+    };
+
+    auto snapshot_tree = [&](ROOT::RDF::RNode df, const std::string &directory_path) {
         if (!filter_expr.empty()) {
-            log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Applying filter to", tree_path);
+            log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Applying filter to",
+                      directory_path + '/' + kEventsTreeName);
             df = df.Filter(filter_expr);
         }
-        log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Writing tree", tree_path, "to", output_file);
-        df.Snapshot(tree_path, output_file, columns, opts);
+        log::info("SnapshotPipelineBuilder::snapshot", "[debug]", "Writing tree",
+                  directory_path + '/' + kEventsTreeName, "to", output_file);
+        auto tree_opts = opts;
+        df.Snapshot(kEventsTreeName, output_file, columns, tree_opts);
+        relocateTreeToDirectory(directory_path);
         wrote_anything = true;
         ++processed_trees;
         log::info("SnapshotPipelineBuilder::snapshot", "[progress]", "Wrote", processed_trees, '/', total_trees,
-                  "trees -", tree_path);
+                  "trees -", directory_path + '/' + kEventsTreeName);
     };
 
     for (auto const &[key, sample] : frames_) {
@@ -296,9 +358,10 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
         const std::string sample_period = rc ? rc->runPeriod() : std::string{};
         const std::string &sample_stage = sample.stageName();
 
-        const auto nominal_tree_path =
-            nominalTreePath(key, sample_beam, sample_period, sample.sampleOrigin(), sample_stage);
-        snapshot_tree(sample.nominalNode(), nominal_tree_path);
+        const auto nominal_directory_components =
+            nominalDirectoryComponents(key, sample_beam, sample_period, sample.sampleOrigin(), sample_stage);
+        const auto nominal_directory_path = componentsToPath(nominal_directory_components);
+        snapshot_tree(sample.nominalNode(), nominal_directory_path);
         const auto &variation_nodes = sample.variationNodes();
         for (const auto &variation_def : sample.variationDescriptors()) {
             auto it = variation_nodes.find(variation_def.variation);
@@ -311,9 +374,11 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
             const std::string &variation_stage =
                 variation_def.stage_name.empty() ? sample_stage : variation_def.stage_name;
 
-            const auto variation_tree_path = variationTreePath(key, variation_def, variation_beam, variation_period,
-                                                               sample.sampleOrigin(), variation_stage);
-            snapshot_tree(it->second, variation_tree_path);
+            const auto variation_directory_components =
+                variationDirectoryComponents(key, variation_def, variation_beam, variation_period,
+                                             sample.sampleOrigin(), variation_stage);
+            const auto variation_directory_path = componentsToPath(variation_directory_components);
+            snapshot_tree(it->second, variation_directory_path);
         }
     }
 

--- a/tests/integration/create_test_sample.C
+++ b/tests/integration/create_test_sample.C
@@ -1,0 +1,113 @@
+#include "TDirectory.h"
+#include "TError.h"
+#include "TFile.h"
+#include "TTree.h"
+
+#include <string>
+#include <vector>
+
+void create_test_sample(const char *filename) {
+    TFile file(filename, "RECREATE");
+    if (file.IsZombie()) {
+        Error("create_test_sample", "Could not create output file %s", filename);
+        return;
+    }
+
+    TDirectory *dir = file.mkdir("nuselection");
+    if (!dir) {
+        Error("create_test_sample", "Could not create nuselection directory");
+        return;
+    }
+    dir->cd();
+
+    TTree tree("EventSelectionFilter", "Integration test sample");
+
+    int run = 1001;
+    int sub = 2;
+    int evt = 3;
+
+    std::vector<float> track_shower_scores{0.95f};
+    std::vector<float> trk_llr_pid_v{0.9f};
+    std::vector<float> track_length{15.f};
+    std::vector<float> track_distance_to_vertex{1.5f};
+    std::vector<float> track_start_x{120.f};
+    std::vector<float> track_start_y{-10.f};
+    std::vector<float> track_start_z{400.f};
+    std::vector<float> track_end_x{130.f};
+    std::vector<float> track_end_y{-5.f};
+    std::vector<float> track_end_z{450.f};
+    std::vector<unsigned> pfp_generations{2u};
+    std::vector<int> pfp_num_plane_hits_U{2};
+    std::vector<int> pfp_num_plane_hits_V{2};
+    std::vector<int> pfp_num_plane_hits_Y{2};
+    std::vector<float> track_theta{0.4f};
+
+    std::vector<std::string> blip_process{"null"};
+    std::vector<float> blip_x{10.f};
+    std::vector<float> blip_y{15.f};
+    std::vector<float> blip_z{20.f};
+
+    float reco_neutrino_vertex_x = 100.f;
+    float reco_neutrino_vertex_y = 5.f;
+    float reco_neutrino_vertex_z = 400.f;
+
+    float reco_neutrino_vertex_sce_x = 102.f;
+    float reco_neutrino_vertex_sce_y = 6.f;
+    float reco_neutrino_vertex_sce_z = 402.f;
+
+    float optical_filter_pe_beam = 50.f;
+    float optical_filter_pe_veto = 5.f;
+    int num_slices = 1;
+    float topological_score = 0.9f;
+    float contained_fraction = 0.8f;
+    float slice_cluster_fraction = 0.75f;
+    int software_trigger = 1;
+
+    tree.Branch("run", &run);
+    tree.Branch("sub", &sub);
+    tree.Branch("evt", &evt);
+
+    tree.Branch("track_shower_scores", &track_shower_scores);
+    tree.Branch("trk_llr_pid_v", &trk_llr_pid_v);
+    tree.Branch("track_length", &track_length);
+    tree.Branch("track_distance_to_vertex", &track_distance_to_vertex);
+    tree.Branch("track_start_x", &track_start_x);
+    tree.Branch("track_start_y", &track_start_y);
+    tree.Branch("track_start_z", &track_start_z);
+    tree.Branch("track_end_x", &track_end_x);
+    tree.Branch("track_end_y", &track_end_y);
+    tree.Branch("track_end_z", &track_end_z);
+    tree.Branch("pfp_generations", &pfp_generations);
+    tree.Branch("pfp_num_plane_hits_U", &pfp_num_plane_hits_U);
+    tree.Branch("pfp_num_plane_hits_V", &pfp_num_plane_hits_V);
+    tree.Branch("pfp_num_plane_hits_Y", &pfp_num_plane_hits_Y);
+    tree.Branch("track_theta", &track_theta);
+
+    tree.Branch("blip_process", &blip_process);
+    tree.Branch("blip_x", &blip_x);
+    tree.Branch("blip_y", &blip_y);
+    tree.Branch("blip_z", &blip_z);
+
+    tree.Branch("reco_neutrino_vertex_x", &reco_neutrino_vertex_x);
+    tree.Branch("reco_neutrino_vertex_y", &reco_neutrino_vertex_y);
+    tree.Branch("reco_neutrino_vertex_z", &reco_neutrino_vertex_z);
+
+    tree.Branch("reco_neutrino_vertex_sce_x", &reco_neutrino_vertex_sce_x);
+    tree.Branch("reco_neutrino_vertex_sce_y", &reco_neutrino_vertex_sce_y);
+    tree.Branch("reco_neutrino_vertex_sce_z", &reco_neutrino_vertex_sce_z);
+
+    tree.Branch("optical_filter_pe_beam", &optical_filter_pe_beam);
+    tree.Branch("optical_filter_pe_veto", &optical_filter_pe_veto);
+    tree.Branch("num_slices", &num_slices);
+    tree.Branch("topological_score", &topological_score);
+    tree.Branch("contained_fraction", &contained_fraction);
+    tree.Branch("slice_cluster_fraction", &slice_cluster_fraction);
+    tree.Branch("software_trigger", &software_trigger);
+
+    tree.Fill();
+    tree.Write("", TObject::kOverwrite);
+
+    dir->cd();
+    file.Write("", TObject::kOverwrite);
+    file.Close();
+}

--- a/tests/integration/run_snapshot_analysis_imt.sh.in
+++ b/tests/integration/run_snapshot_analysis_imt.sh.in
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATA_DIR="@RAREXSEC_TEST_BINARY_DIR@/snapshot_imt"
+INPUT_FILE="${DATA_DIR}/input.root"
+OUTPUT_FILE="${DATA_DIR}/snapshot.root"
+CONFIG_FILE="${DATA_DIR}/config.json"
+LOG_FILE="${DATA_DIR}/snapshot.log"
+MACRO_PATH="@RAREXSEC_TEST_SOURCE_DIR@/tests/integration/create_test_sample.C"
+SNAPSHOT_ANALYSIS="@RAREXSEC_SNAPSHOT_ANALYSIS_EXEC@"
+ROOT_EXEC="@RAREXSEC_ROOT_EXECUTABLE@"
+
+rm -rf "${DATA_DIR}"
+mkdir -p "${DATA_DIR}"
+
+"${ROOT_EXEC}" -l -b -q "${MACRO_PATH}(\"${INPUT_FILE}\")"
+
+if [[ ! -f "${INPUT_FILE}" ]]; then
+    echo "Failed to generate test input file" >&2
+    exit 1
+fi
+
+INPUT_BASENAME="$(basename "${INPUT_FILE}")"
+
+cat > "${CONFIG_FILE}" <<JSON
+{
+  "ntuple_base_directory": "${DATA_DIR}",
+  "run_configurations": {
+    "test-beam": {
+      "run1": {
+        "nominal_triggers": 1,
+        "samples": [
+          {
+            "sample_key": "test_sample",
+            "sample_type": "data",
+            "relative_path": "${INPUT_BASENAME}",
+            "triggers": 1
+          }
+        ]
+      }
+    }
+  }
+}
+JSON
+
+"${SNAPSHOT_ANALYSIS}" "${CONFIG_FILE}" "test-beam" "run1" "" "${OUTPUT_FILE}" >"${LOG_FILE}" 2>&1
+
+if grep -q "TDirectoryFile::mkdir" "${LOG_FILE}"; then
+    echo "Encountered TDirectoryFile::mkdir error during snapshot" >&2
+    cat "${LOG_FILE}" >&2
+    exit 1
+fi
+
+python3 - <<PY
+import ROOT
+import sys
+
+output_file = r"${OUTPUT_FILE}"
+tree_path = "samples/test-beam/run1/data/test_sample/nominal/events"
+
+f = ROOT.TFile.Open(output_file)
+if not f or f.IsZombie():
+    print(f"Failed to open snapshot output {output_file}", file=sys.stderr)
+    sys.exit(1)
+
+tree = f.Get(tree_path)
+if not tree:
+    print("Expected events tree not found in snapshot", file=sys.stderr)
+    sys.exit(1)
+PY


### PR DESCRIPTION
## Summary
- guard snapshot directory setup with an IMT-aware helper, ensure all path components are created sequentially, and relocate each tree into its prepared directory after snapshotting
- add a minimal ROOT sample generator and integration shell test that runs snapshot-analysis with IMT enabled and verifies the events tree lands in the expected subdirectory

## Testing
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68cf09eb4ee4832e84db302c15cd22bd