### PR TITLE
Fix WeightProcessor redefining base weight with typed lambda

### DIFF
--- a/src/WeightProcessor.cpp
+++ b/src/WeightProcessor.cpp
@@ -26,7 +26,7 @@ ROOT::RDF::RNode WeightProcessor::process(ROOT::RDF::RNode df, SampleOrigin st) 
         if (proc_df.HasColumn("base_event_weight")) {
             proc_df = proc_df.Redefine(
                 "base_event_weight",
-                [scale](const auto &weight) { return weight * scale; },
+                [scale](double weight) { return weight * scale; },
                 {"base_event_weight"});
         } else {
             proc_df = proc_df.Define("base_event_weight", [scale]() { return scale; });
@@ -58,7 +58,7 @@ ROOT::RDF::RNode WeightProcessor::process(ROOT::RDF::RNode df, SampleOrigin st) 
         if (proc_df.HasColumn("base_event_weight")) {
             proc_df = proc_df.Redefine(
                 "base_event_weight",
-                [scale](const auto &weight) { return weight * scale; },
+                [scale](double weight) { return weight * scale; },
                 {"base_event_weight"});
         } else {
             proc_df = proc_df.Define("base_event_weight", [scale]() { return scale; });


### PR DESCRIPTION
## Summary
- replace the generic lambda passed to `RNode::Redefine` in `WeightProcessor` with a typed overload
- ensure base event weight scaling keeps working when ROOT inspects the callable

## Testing
- cmake -S . -B build *(fails: missing ROOT configuration in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf36667b4c832e9e53acd5ed27e07a