### PR TITLE
Refactor snapshot scheduling for concurrent execution

### DIFF
--- a/tests/SnapshotAnalysisRegressionTest.cpp
+++ b/tests/SnapshotAnalysisRegressionTest.cpp
@@ -345,6 +345,12 @@ int main(int argc, char **argv) {
             baseline_entries.push_back(readTreeEntries(output_path, expectation));
         }
 
+        ensure(expectations.size() >= 2, "Regression test requires at least two samples to validate RunGraphs execution");
+        ensure(baseline_entries.size() >= 2,
+               "Unexpected baseline entry count while validating multi-job RunGraphs execution");
+        ensure(baseline_entries[0] > 0, "First sample produced no entries after RunGraphs execution");
+        ensure(baseline_entries[1] > 0, "Second sample produced no entries after RunGraphs execution");
+
         const auto second_result = executeSnapshot(snapshot_executable, config_path, period_argument, output_path);
         ensure(second_result.exit_code == 0, "Second snapshot-analysis invocation failed");
 


### PR DESCRIPTION
## Summary
- queue snapshot jobs with lazy snapshots writing to temporary sinks and run them together via ROOT::RDF::RunGraphs
- import each job's output into the final snapshot layout with the direct-write helper and clean up temporary files
- extend the regression test to assert multiple samples complete when RunGraphs is used

## Testing
- make -j2 *(fails: missing ROOT development package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc9a9f788832e88af32a5dc11d51f