### PR TITLE
Add analysis aliases and cutflow metadata to snapshots

### DIFF
--- a/include/rarexsec/SnapshotPipelineBuilder.h
+++ b/include/rarexsec/SnapshotPipelineBuilder.h
@@ -18,6 +18,27 @@ class TFile;
 
 namespace proc {
 
+struct ProvenanceDicts {
+  std::unordered_map<std::string, uint32_t> sample2id;
+  std::unordered_map<std::string, uint16_t> beam2id, period2id, stage2id, var2id;
+  std::unordered_map<SampleOrigin, uint8_t> origin2id;
+};
+
+struct CutflowRow {
+  uint32_t sample_id;
+  uint16_t variation_id, beam_id, period_id, stage_id;
+  uint8_t origin_id;
+  unsigned long long n_total = 0ULL;
+  unsigned long long n_base = 0ULL;
+
+  std::string sample_key;
+  std::string variation;
+  std::string beam;
+  std::string period;
+  std::string stage;
+  std::string origin;
+};
+
 class SnapshotPipelineBuilder {
   public:
     using SampleFrameMap = std::map<SampleKey, SamplePipeline>;
@@ -65,7 +86,9 @@ class SnapshotPipelineBuilder {
     std::unique_ptr<EventProcessorStage> chainProcessorStages(std::unique_ptr<Head> head,
                                                               std::unique_ptr<Tail>... tail);
 
-    void writeSnapshotMetadata(TFile &output_file) const;
+    void writeSnapshotMetadata(TFile &output_file,
+                               const ProvenanceDicts &dicts,
+                               const std::vector<CutflowRow> &cutflow) const;
 };
 
 template <typename Head, typename... Tail>


### PR DESCRIPTION
## Summary
- extend the snapshot builder to attach provenance IDs and analysis-friendly aliases such as event_uid, base_sel, and w_nom
- build per-combination cutflow counters while sharing the event loop and emit the results alongside provenance dictionaries
- reopen the output file to add a (rsub_key, evt) index and enriched metadata, including a schema marker and updated samples table

## Testing
- `cmake -S . -B build` *(fails: missing ROOT package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11599725c832e8db387425c7d20f1