### PR TITLE
Refactor truth channel processing to single compute

### DIFF
--- a/include/rarexsec/TruthChannelProcessor.h
+++ b/include/rarexsec/TruthChannelProcessor.h
@@ -11,10 +11,6 @@ class TruthChannelProcessor : public EventProcessorStage {
 
   private:
     ROOT::RDF::RNode processData(ROOT::RDF::RNode df, SampleOrigin st) const;
-    ROOT::RDF::RNode defineCounts(ROOT::RDF::RNode df) const;
-    ROOT::RDF::RNode assignInclusiveChannels(ROOT::RDF::RNode df) const;
-    ROOT::RDF::RNode assignExclusiveChannels(ROOT::RDF::RNode df) const;
-    ROOT::RDF::RNode assignChannelDefinitions(ROOT::RDF::RNode df) const;
 };
 
 }


### PR DESCRIPTION
## Summary
- compute MC truth channel properties in a single Define that fills a TruthDerived helper
- expose the derived truth members as lightweight columns and remove the old staged helpers
- drop the unused helper declarations from the TruthChannelProcessor interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d122419f5c832e9dcef074de47c26d