### PR TITLE
Fix snapshot snapshot handle type

### DIFF
--- a/src/SnapshotPipelineBuilder.cpp
+++ b/src/SnapshotPipelineBuilder.cpp
@@ -12,11 +12,13 @@
 #include <cctype>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include <rarexsec/BlipProcessor.h>
 #include <rarexsec/LoggerUtils.h>
@@ -338,9 +340,13 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
     base_opt.fCompressionLevel = 3;
 
     // Per-(sample, variation) results, one dataframe per node
+    using SnapshotResultHandle = decltype(std::declval<ROOT::RDF::RNode>().Snapshot(
+        std::declval<std::string>(), std::declval<std::string>(),
+        std::declval<std::vector<std::string>>(), std::declval<ROOT::RDF::RSnapshotOptions>()));
+
     struct CountHandles {
         CutflowRow row;
-        ROOT::RDF::RResultPtr<ULong64_t> snapshot;
+        SnapshotResultHandle snapshot;
         ROOT::RDF::RResultPtr<ULong64_t> n_total;
         ROOT::RDF::RResultPtr<ULong64_t> n_base;
     };


### PR DESCRIPTION
## Summary
- include the standard headers required by SnapshotPipelineBuilder.cpp
- store the snapshot handle using the type returned by ROOT RDataFrame::Snapshot

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: ROOT development files are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d12ec1c854832e804cbfe598fa4b3f