### PR TITLE
Generate ROOT dictionary for TruthDerived column

### DIFF
--- a/include/rarexsec/TruthDerived.h
+++ b/include/rarexsec/TruthDerived.h
@@ -1,0 +1,21 @@
+#ifndef RAREXSEC_TRUTH_DERIVED_H
+#define RAREXSEC_TRUTH_DERIVED_H
+
+namespace proc {
+
+struct TruthDerived {
+    bool in_fiducial;
+    int mc_n_strange;
+    int mc_n_pion;
+    int mc_n_proton;
+    int interaction_mode_category;
+    int inclusive_strange_channel_category;
+    int exclusive_strange_channel_category;
+    int channel_definition_category;
+    bool is_truth_signal;
+    bool pure_slice_signal;
+};
+
+} // namespace proc
+
+#endif // RAREXSEC_TRUTH_DERIVED_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,10 @@ set(rarexsec_processing_sources
     WeightProcessor.cpp
 )
 
+set(rarexsec_processing_dictionary_headers
+    ${PROJECT_SOURCE_DIR}/include/rarexsec/TruthDerived.h
+)
+
 add_library(rarexsec_processing)
 add_library(rarexsec::processing ALIAS rarexsec_processing)
 
@@ -40,6 +44,27 @@ target_compile_features(rarexsec_processing PUBLIC cxx_std_17)
 
 set_target_properties(rarexsec_processing PROPERTIES EXPORT_NAME processing)
 
+ROOT_GENERATE_DICTIONARY(G__rarexsec
+    ${rarexsec_processing_dictionary_headers}
+    MODULE rarexsec_processing
+    LINKDEF RarexsecDictLinkDef.h
+)
+
+ROOT_GET_LIBRARY_OUTPUT_DIR(rarexsec_processing_library_output_dir)
+
+set(rarexsec_processing_dictionary_rootmap
+    ${rarexsec_processing_library_output_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}rarexsec_processing.rootmap)
+set(rarexsec_processing_dictionary_pcm
+    ${rarexsec_processing_library_output_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}rarexsec_processing_rdict.pcm)
+
+set(rarexsec_processing_dictionary_files)
+if(rarexsec_processing_dictionary_pcm)
+    list(APPEND rarexsec_processing_dictionary_files ${rarexsec_processing_dictionary_pcm})
+endif()
+if(rarexsec_processing_dictionary_rootmap)
+    list(APPEND rarexsec_processing_dictionary_files ${rarexsec_processing_dictionary_rootmap})
+endif()
+
 install(
     TARGETS rarexsec_processing
     EXPORT ${RAREXSEC_EXPORT_SET}
@@ -47,6 +72,13 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(rarexsec_processing_dictionary_files)
+    install(
+        FILES ${rarexsec_processing_dictionary_files}
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
 
 install(
     DIRECTORY ${PROJECT_SOURCE_DIR}/include/

--- a/src/RarexsecDictLinkDef.h
+++ b/src/RarexsecDictLinkDef.h
@@ -1,0 +1,8 @@
+#ifdef __CLING__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ namespace proc;
+#pragma link C++ struct proc::TruthDerived+;
+#endif

--- a/src/TruthChannelProcessor.cpp
+++ b/src/TruthChannelProcessor.cpp
@@ -1,5 +1,6 @@
 #include <rarexsec/TruthChannelProcessor.h>
 #include <rarexsec/SelectionCatalogue.h>
+#include <rarexsec/TruthDerived.h>
 
 #include <cmath>
 
@@ -23,19 +24,6 @@ DataSampleChannelInfo channelInfoForDataSample(SampleOrigin origin) {
         return {99, 99};
     }
 }
-
-struct TruthDerived {
-    bool in_fiducial;
-    int mc_n_strange;
-    int mc_n_pion;
-    int mc_n_proton;
-    int interaction_mode_category;
-    int inclusive_strange_channel_category;
-    int exclusive_strange_channel_category;
-    int channel_definition_category;
-    bool is_truth_signal;
-    bool pure_slice_signal;
-};
 
 inline int to_mode_cat(int mode) {
     switch (mode) {


### PR DESCRIPTION
## Summary
- expose the TruthDerived struct in a public header so it can be referenced outside the translation unit
- generate and install a ROOT dictionary for the processing library to register the TruthDerived column with the interpreter
- add the LinkDef header required for rootcling to build the dictionary

## Testing
- make *(fails: ROOT not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1302547a8832eaafabf09fcc983c9