### PR TITLE
Fix ROOT Define usage with typed lambdas

### DIFF
--- a/src/SnapshotPipelineBuilder.cpp
+++ b/src/SnapshotPipelineBuilder.cpp
@@ -145,19 +145,14 @@ static ROOT::RDF::RNode defineAnalysisAliases(ROOT::RDF::RNode df) {
     if (has_run && has_sub && has_evt) {
         df = df.Define(
                      "event_uid",
-                     [](auto run, auto sub, auto evt) {
-                         const auto run_u = static_cast<ULong64_t>(run);
-                         const auto sub_u = static_cast<ULong64_t>(sub);
-                         const auto evt_u = static_cast<ULong64_t>(evt);
-                         return (run_u << 42) | (sub_u << 21) | evt_u;  // [run|sub|evt]
+                     [](ULong64_t run, ULong64_t sub, ULong64_t evt) {
+                         return (run << 42) | (sub << 21) | evt;  // [run|sub|evt]
                      },
                      {"run", "sub", "evt"})
                  .Define(
                      "rsub_key",
-                     [](auto run, auto sub) {
-                         const auto run_u = static_cast<ULong64_t>(run);
-                         const auto sub_u = static_cast<ULong64_t>(sub);
-                         return (run_u << 20) | sub_u;
+                     [](ULong64_t run, ULong64_t sub) {
+                         return (run << 20) | sub;
                      },
                      {"run", "sub"});
     } else {


### PR DESCRIPTION
## Summary
- replace generic lambdas in `defineAnalysisAliases` with explicit `ULong64_t` parameters
- avoid ROOT `Define` callable trait deduction failures when building snapshot processing

## Testing
- `cmake -S . -B build` *(fails: missing ROOT package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1366656d4832eb921e45bdbea02f3