### PR TITLE
Fix ROOT gDirectory null check for ROOT atomic adapter

### DIFF
--- a/src/SnapshotPipelineBuilder.cpp
+++ b/src/SnapshotPipelineBuilder.cpp
@@ -459,8 +459,8 @@ void SnapshotPipelineBuilder::snapshot(const std::string &filter_expr, const std
             if (auto canvases = gROOT->GetListOfCanvases()) {
                 canvases->Delete();
             }
-            if (gDirectory != nullptr) {
-                if (auto dir_list = gDirectory->GetList()) {
+            if (TDirectory *dir = gDirectory) {
+                if (auto dir_list = dir->GetList()) {
                     dir_list->Delete();
                 }
             }


### PR DESCRIPTION
## Summary
- replace the direct nullptr comparison on gDirectory with a local pointer
  retrieved via the adapter to avoid ambiguous overload resolution when
  ROOT uses the TDirectoryAtomicAdapter wrapper

## Testing
- cmake -S . -B build *(fails: missing ROOT package configuration in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1526c4998832e9ac6c63688f80734