### PR TITLE
Implement processor pipeline pattern

### DIFF
--- a/include/rarexsec/EventProcessorStage.h
+++ b/include/rarexsec/EventProcessorStage.h
@@ -1,8 +1,6 @@
 #ifndef EVENT_PROCESSOR_STAGE_H
 #define EVENT_PROCESSOR_STAGE_H
 
-#include <memory>
-
 #include "ROOT/RDataFrame.hxx"
 
 #include <rarexsec/SampleTypes.h>
@@ -14,11 +12,6 @@ class EventProcessorStage {
     virtual ~EventProcessorStage() = default;
 
     virtual ROOT::RDF::RNode process(ROOT::RDF::RNode df, SampleOrigin st) const = 0;
-
-    void chainNextStage(std::unique_ptr<EventProcessorStage> next) { next_ = std::move(next); }
-
-  protected:
-    std::unique_ptr<EventProcessorStage> next_;
 };
 
 }

--- a/include/rarexsec/ProcessorPipeline.h
+++ b/include/rarexsec/ProcessorPipeline.h
@@ -1,0 +1,46 @@
+#ifndef PROCESSOR_PIPELINE_H
+#define PROCESSOR_PIPELINE_H
+
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <rarexsec/EventProcessorStage.h>
+
+namespace proc {
+
+template <typename... Processors>
+class ProcessorPipeline : public EventProcessorStage {
+  static_assert(sizeof...(Processors) > 0, "ProcessorPipeline requires at least one processor stage");
+  static_assert((std::is_base_of_v<EventProcessorStage, Processors> && ...),
+                "All processors must derive from EventProcessorStage");
+
+  using ProcessorTuple = std::tuple<std::unique_ptr<Processors>...>;
+
+  public:
+    explicit ProcessorPipeline(std::unique_ptr<Processors>... processors)
+        : processors_(std::move(processors)...) {}
+
+    ProcessorPipeline(const ProcessorPipeline &) = delete;
+    ProcessorPipeline &operator=(const ProcessorPipeline &) = delete;
+    ProcessorPipeline(ProcessorPipeline &&) noexcept = default;
+    ProcessorPipeline &operator=(ProcessorPipeline &&) noexcept = default;
+
+    ROOT::RDF::RNode process(ROOT::RDF::RNode df, SampleOrigin origin) const override {
+        return std::apply(
+            [&](auto const &...processor) {
+                ROOT::RDF::RNode current = std::move(df);
+                ((current = processor->process(current, origin)), ...);
+                return current;
+            },
+            processors_);
+    }
+
+  private:
+    ProcessorTuple processors_;
+};
+
+} // namespace proc
+
+#endif

--- a/include/rarexsec/SnapshotPipelineBuilder.h
+++ b/include/rarexsec/SnapshotPipelineBuilder.h
@@ -82,26 +82,10 @@ class SnapshotPipelineBuilder {
     void loadAll();
     void processRunConfig(const RunConfig &rc);
 
-    template <typename Head, typename... Tail>
-    std::unique_ptr<EventProcessorStage> chainProcessorStages(std::unique_ptr<Head> head,
-                                                              std::unique_ptr<Tail>... tail);
-
     void writeSnapshotMetadata(TFile &output_file,
                                const ProvenanceDicts &dicts,
                                const std::vector<CutflowRow> &cutflow) const;
 };
-
-template <typename Head, typename... Tail>
-std::unique_ptr<EventProcessorStage> SnapshotPipelineBuilder::chainProcessorStages(std::unique_ptr<Head> head,
-                                                                                   std::unique_ptr<Tail>... tail) {
-    if constexpr (sizeof...(tail) == 0) {
-        return head;
-    } else {
-        auto next = this->chainProcessorStages(std::move(tail)...);
-        head->chainNextStage(std::move(next));
-        return head;
-    }
-}
 
 }
 

--- a/src/BlipProcessor.cpp
+++ b/src/BlipProcessor.cpp
@@ -77,7 +77,7 @@ ROOT::RDF::RNode BlipProcessor::process(ROOT::RDF::RNode df, SampleOrigin st) co
         proc_df = proc_df.Define("blip_distance_to_vertex", missingVertexDistances, {"blip_x"});
     }
 
-    return next_ ? next_->process(proc_df, st) : proc_df;
+    return proc_df;
 }
 
 }

--- a/src/MuonSelectionProcessor.cpp
+++ b/src/MuonSelectionProcessor.cpp
@@ -58,7 +58,7 @@ ROOT::RVec<float> computeMaskedCosTheta(const ROOT::RVec<float> &theta, const RO
 
 ROOT::RDF::RNode MuonSelectionProcessor::process(ROOT::RDF::RNode df, SampleOrigin st) const {
     auto processed = extractMuonFeatures(buildMuonMask(std::move(df)));
-    return next_ ? next_->process(std::move(processed), st) : processed;
+    return processed;
 }
 
 ROOT::RDF::RNode MuonSelectionProcessor::buildMuonMask(ROOT::RDF::RNode df) const {

--- a/src/PreselectionProcessor.cpp
+++ b/src/PreselectionProcessor.cpp
@@ -40,7 +40,7 @@ ROOT::RDF::RNode PreselectionProcessor::process(ROOT::RDF::RNode df, SampleOrigi
                               "pass_mu",
                               "pass_topo"});
 
-    return next_ ? next_->process(final_df, st) : final_df;
+    return final_df;
 }
 
 }

--- a/src/ReconstructionProcessor.cpp
+++ b/src/ReconstructionProcessor.cpp
@@ -35,7 +35,7 @@ ROOT::RDF::RNode ReconstructionProcessor::process(ROOT::RDF::RNode df, SampleOri
          "contained_fraction",
          "slice_cluster_fraction"});
 
-    return next_ ? next_->process(quality_df, st) : quality_df;
+    return quality_df;
 }
 
 }

--- a/src/SnapshotPipelineBuilder.cpp
+++ b/src/SnapshotPipelineBuilder.cpp
@@ -27,6 +27,7 @@
 #include <rarexsec/LoggerUtils.h>
 #include <rarexsec/MuonSelectionProcessor.h>
 #include <rarexsec/PreselectionProcessor.h>
+#include <rarexsec/ProcessorPipeline.h>
 #include <rarexsec/ReconstructionProcessor.h>
 #include <rarexsec/SampleTypes.h>
 #include <rarexsec/TruthChannelProcessor.h>
@@ -610,7 +611,9 @@ void SnapshotPipelineBuilder::processRunConfig(const RunConfig &rc) {
             continue;
         }
 
-        auto pipeline = this->chainProcessorStages(
+        auto pipeline = std::make_unique<ProcessorPipeline<WeightProcessor, TruthChannelProcessor, BlipProcessor,
+                                                            MuonSelectionProcessor, ReconstructionProcessor,
+                                                            PreselectionProcessor>>(
             std::make_unique<WeightProcessor>(sample_json, total_pot_, total_triggers_),
             std::make_unique<TruthChannelProcessor>(), std::make_unique<BlipProcessor>(),
             std::make_unique<MuonSelectionProcessor>(), std::make_unique<ReconstructionProcessor>(),

--- a/src/TruthChannelProcessor.cpp
+++ b/src/TruthChannelProcessor.cpp
@@ -204,7 +204,7 @@ ROOT::RDF::RNode TruthChannelProcessor::process(ROOT::RDF::RNode df, SampleOrigi
                     .Define("is_truth_signal", truth_column(&TruthDerived::is_truth_signal), {"truth_derived"})
                     .Define("pure_slice_signal", truth_column(&TruthDerived::pure_slice_signal), {"truth_derived"});
 
-    return next_ ? next_->process(out, st) : out;
+    return out;
 }
 
 ROOT::RDF::RNode TruthChannelProcessor::processData(ROOT::RDF::RNode df, SampleOrigin st) const {
@@ -224,7 +224,7 @@ ROOT::RDF::RNode TruthChannelProcessor::processData(ROOT::RDF::RNode df, SampleO
                            .Define("is_truth_signal", []() { return false; })
                            .Define("pure_slice_signal", []() { return false; });
 
-    return next_ ? next_->process(defaults_df, st) : defaults_df;
+    return defaults_df;
 }
 
 }

--- a/src/WeightProcessor.cpp
+++ b/src/WeightProcessor.cpp
@@ -79,7 +79,7 @@ ROOT::RDF::RNode WeightProcessor::process(ROOT::RDF::RNode df, SampleOrigin st) 
         }
     }
 
-    return next_ ? next_->process(proc_df, st) : proc_df;
+    return proc_df;
 }
 
 }


### PR DESCRIPTION
## Summary
- add a ProcessorPipeline template that sequences event processors and drop the manual chaining pointer from EventProcessorStage
- construct processor pipelines inside SnapshotPipelineBuilder instead of recursively wiring stages
- update each processor implementation to return its processed node directly

## Testing
- make build-lib *(fails: missing ROOT package configuration in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1645d5dd8832e99f8f4ca46ef2536