### PR TITLE
Fix ShardWriter default configuration initialization

### DIFF
--- a/include/rarexsec/ShardWriter.h
+++ b/include/rarexsec/ShardWriter.h
@@ -15,9 +15,14 @@ namespace proc {
 class ShardWriter {
   public:
     struct ShardConfig {
-        std::filesystem::path output_dir = std::filesystem::path{"shards"};
-        int compression_algo = ROOT::kZSTD;
-        int compression_level = 3;
+        ShardConfig()
+            : output_dir(std::filesystem::path{"shards"}),
+              compression_algo(ROOT::kZSTD),
+              compression_level(3) {}
+
+        std::filesystem::path output_dir;
+        int compression_algo;
+        int compression_level;
     };
 
     explicit ShardWriter(const ShardConfig &config = ShardConfig{});


### PR DESCRIPTION
## Summary
- provide an explicit `ShardConfig` constructor to initialize shard output path and compression settings
- avoid reliance on default member initializers that some toolchains reject when used in default arguments

## Testing
- `cmake -S . -B build` *(fails: missing ROOT package in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bfb13734832eaf0470f8521c9172