### PR TITLE
Fix ShardWriter compression algorithm type

### DIFF
--- a/include/rarexsec/ShardWriter.h
+++ b/include/rarexsec/ShardWriter.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include <Compression.h>
+
 #include "ROOT/RDataFrame.hxx"
 
 #include <rarexsec/HubCatalog.h>
@@ -21,7 +23,7 @@ class ShardWriter {
               compression_level(3) {}
 
         std::filesystem::path output_dir;
-        int compression_algo;
+        ROOT::ECompressionAlgorithm compression_algo;
         int compression_level;
     };
 


### PR DESCRIPTION
## Summary
- include ROOT's compression header for ShardWriter configuration
- store the shard compression algorithm using ROOT::ECompressionAlgorithm to match RSnapshotOptions

## Testing
- cmake -S . -B build *(fails: missing ROOT package in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c5459e58832ebc48d4068919272f